### PR TITLE
Proof of concept for suspending window on hide

### DIFF
--- a/main/index.ts
+++ b/main/index.ts
@@ -81,8 +81,15 @@ function setupMenuBar(config: Config) {
                 mb.window.webContents.send('chromenu:config', config);
             });
             ipc.on('chromenu:hide-window', () => {
+                log.debug('Hiding window');
                 mb.hideWindow();
             });
+            const win = mb.window;
+            ipc.on('chromenu:suspend-window', () => {
+                log.debug('Suspending window', win);
+                win.loadURL(Html);
+            });
+
             resolve(mb);
         });
     });
@@ -119,7 +126,12 @@ function setupNormalWindow(config: Config) {
                 win.webContents.openDevTools({mode: 'detach'});
             }
             ipc.on('chromenu:hide-window', () => {
+                log.debug('Hiding window');
                 win.hide();
+            });
+            ipc.on('chromenu:suspend-window', () => {
+                log.debug('Suspending window');
+                win.loadURL(Html);
             });
             resolve(win);
         });

--- a/renderer/index.tsx
+++ b/renderer/index.tsx
@@ -75,3 +75,8 @@ remote.getCurrentWindow().on('focus', () => {
         log.debug('Reload page was not reloaded on window focus because interval is shorter than threthold', spent_ms, current.reload_min_interval);
     }
 });
+
+remote.getCurrentWindow().on('hide', () => {
+    log.debug('Window hidden');
+    ipc.send('chromenu:suspend-window');
+});


### PR DESCRIPTION
Hi there! First of all, thanks for creating such a nice and useful little app.

I was wondering how complicated it would be to add an option to make the pages unload when the app is not visible.

Main reason for this is really consumption of resources. I was thinking that this could be very useful for running darksky.net for instance, but darksky is a bit CPU heavy because of all of their fancy graphics stuff and you can hear the fans go off after a while.

I started this proof of concept PR, still not relying on a possible option but just trying to figure out if my idea was possible.

I've never touched any Electron based apps before, so I had a quick look at the code and Electron/menubar docs to figure out what could possibly be done.

Sending the event from the renderer works fine, but the question is what to do when handling the event on the main app. I first tried closing the window which seems to close the whole app and it's no good.

Then I tried this, loading (what I assume is) the default page after hiding, but I always get an error saying the window object isn't available (which is weird, because when I was trying `win.close()` it worked).

Anyway, I thought I'd open a PR with this proof of concept to see if you'd have any ideas on how to make it work.

Thanks in advance if you can look into this :)